### PR TITLE
nuxt3 url fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ This repository is a collection of boilerplate code and project setups with symb
 | Repository                                                                                        | Framework | Author                                        |
 | ------------------------------------------------------------------------------------------------- | --------- | --------------------------------------------- |
 | [expo-symbol-boilerplate](https://github.com/symbol-blockchain-community/expo-symbol-boilerplate) | Expo      | [ymuichiro](https://github.com/ymuichiro)     |
-| [symbol-sdk-v3-nuxt3](https://github.com/ymuichiro/expo-symbol-boilerplate)                       | Nuxt3     | [planethouki](https://github.com/planethouki) |
+| [symbol-sdk-v3-nuxt3](https://github.com/planethouki/symbol-sdk-v3-nuxt3)                         | Nuxt3     | [planethouki](https://github.com/planethouki) |
 | [next-symbol-sdk](https://github.com/AnthonyLaw/next-symbol-sdk)                                  | NextJS    | [AnthonyLaw](https://github.com/AnthonyLaw)   |


### PR DESCRIPTION
The link for symbol-sdk-v3-nuxt3 is incorrect and I want to correct it.